### PR TITLE
Ability to use 'submit_button' component in a multi-level webform-structure (tree).

### DIFF
--- a/webform_submit_button.module
+++ b/webform_submit_button.module
@@ -99,7 +99,7 @@ function webform_submit_button_form_alter(&$form, &$form_state, $form_id) {
       $actions = $form['actions'];
       $actions['#weight'] = $current_weight;
 
-      unset($form['actions']);
+      $form['actions']['#access'] = FALSE;
       $element = $actions;
     }
   }

--- a/webform_submit_button.module
+++ b/webform_submit_button.module
@@ -11,22 +11,22 @@
 function webform_submit_button_webform_component_info() {
   $components = array();
   $components['submit_button'] = array(
-    'label' => t('Submit button'),
+    'label'       => t('Submit button'),
     'description' => t('Displays Submit Button in the Form as a webform component.'),
-    'features' => array(
-      'analysis' => FALSE,
-      'csv' => FALSE,
-      'default_value' => FALSE,
-      'description' => FALSE,
-      'email' => FALSE,
-      'required' => FALSE,
-      'conditional' => FALSE,
-      'title_display' => FALSE,
-      'private' => FALSE,
+    'features'    => array(
+      'analysis'        => FALSE,
+      'csv'             => FALSE,
+      'default_value'   => FALSE,
+      'description'     => FALSE,
+      'email'           => FALSE,
+      'required'        => FALSE,
+      'conditional'     => FALSE,
+      'title_display'   => FALSE,
+      'private'         => FALSE,
       'wrapper_classes' => FALSE,
-      'css_classes' => FALSE,
+      'css_classes'     => FALSE,
     ),
-    'file' => 'webform_submit_button_component.inc',
+    'file'        => 'webform_submit_button_component.inc',
   );
 
   return $components;
@@ -55,7 +55,6 @@ function webform_submit_button_form_alter(&$form, &$form_state, $form_id) {
     $current_component_type = $value['#webform_component']['type'];
 
     if ($current_component_type == 'submit_button') {
-
       // Get the weight of the user's submit button component.
       $current_weight = $value['#webform_component']['weight'];
 
@@ -64,12 +63,69 @@ function webform_submit_button_form_alter(&$form, &$form_state, $form_id) {
       $actions['#weight'] = $current_weight;
 
       // Move the webform submit button into the position of the
-      // user's submit button component.  Remove the user's component since it
+      // user's submit button component. Remove the user's component since it
       // was really just a placeholder for the real thing.
 
       unset($form['actions']);
       unset($form['submitted'][$key]);
       $form['submitted']['submit_button'] = $actions;
+
+      // 'submit_button' is found at the top level, so we return now.
+      return;
     }
   }
+
+  // Try to find 'submit_button' component somewhere in the "haystack".
+  $tree = _webform_submit_button_find_component($form['submitted']);
+
+  if(!empty($tree)) {
+    $tree = array_reverse($tree);
+
+    // Try to make a reference to the 'submit_button' component.
+    foreach ($tree as $key => $value) {
+      if(!isset($element)) {
+        $element = &$form['submitted'][$value];
+        continue;
+      }
+
+      $element = &$element[$value];
+    }
+
+    if(!empty($element)) {
+      // Get the weight of the user's submit button component.
+      $current_weight = $element['#webform_component']['weight'];
+
+      // Apply the weight to the actual webform submit button.
+      $actions = $form['actions'];
+      $actions['#weight'] = $current_weight;
+
+      unset($form['actions']);
+      $element = $actions;
+    }
+  }
+
+}
+
+/**
+ * Helper function to find "submit_button" component somewhere in a "haystack".
+ */
+function _webform_submit_button_find_component($components, &$tree = array()) {
+  foreach ($components as $key => $value) {
+    if (!isset($value['#webform_component']['type'])) {
+      continue;
+    }
+
+    if ($value['#webform_component']['type'] == 'submit_button') {
+      $tree[] = $key;
+      return $tree;
+    }
+
+    $found = _webform_submit_button_find_component($value, $tree);
+    if (!empty($found)) {
+      $tree[] = $key;
+      return $tree;
+    }
+  }
+
+  return $tree;
 }


### PR DESCRIPTION
Example webform-structure (using Webform Bootstrap 3 Layout module):

![kepernyokep_2017-01-18_11-40-04](https://cloud.githubusercontent.com/assets/6043821/22061335/d0e11184-dd74-11e6-95a4-c92b0a3a3284.png)

Result ('submit_button' appear in the right column):

![kepernyokep_2017-01-18_11-53-00](https://cloud.githubusercontent.com/assets/6043821/22061358/eb5b71d0-dd74-11e6-8b01-8fa2eb089c79.png)

Sorry for hungarian contents, and thank you for this awesome module! :)

